### PR TITLE
Fix error when value is equal to 0

### DIFF
--- a/ha_mqtt_device.py
+++ b/ha_mqtt_device.py
@@ -83,7 +83,7 @@ class Sensor(Component):
         ).wait_for_publish()
 
     def send(self, value=None, blocking=False):
-        if not value:
+        if value is None:
             if not self.value_read_function:
                 raise ValueError("Set either value or value_read_function")
 


### PR DESCRIPTION
Before this commit a perfectly fine value of 0 on a sensor would result in an error.