### PR TITLE
Retain the config topic

### DIFF
--- a/ha_mqtt_device.py
+++ b/ha_mqtt_device.py
@@ -80,6 +80,7 @@ class Sensor(Component):
         self.client.publish(
             f"{DISCOVERY_PREFIX}/{self.component}/{self.parent_device.name}/{self.object_id}/config",
             json.dumps(_config),
+            retain=True,
         ).wait_for_publish()
 
     def send(self, value=None, blocking=False):


### PR DESCRIPTION
This ensures a restarted HA instance will get the config without having to republish.

This is also how ESPHome does it.