### PR TITLE
Added support for force_update in MQTT Sensor autoconfiguration.

### DIFF
--- a/ha_mqtt_device.py
+++ b/ha_mqtt_device.py
@@ -52,12 +52,14 @@ class Sensor(Component):
         unit_of_measurement,
         icon=None,
         topic_parent_level="",
+        force_update = False
     ):
         super().__init__("sensor")
 
         self.client = client
         self.name = name
         self.parent_device = parent_device
+        self.force_update = force_update
         self.object_id = self.name.replace(" ", "_").lower()
         self.unit_of_measurement = unit_of_measurement
         self.icon = icon
@@ -72,6 +74,7 @@ class Sensor(Component):
             "state_topic": "~/state",
             "unit_of_measurement": self.unit_of_measurement,
             "device": self.parent_device,
+            "force_update": self.force_update
         }
 
         if self.icon:


### PR DESCRIPTION
By default, HomeAssistant will not show the last time the sensor has been published, rather the last time it was changed. MQTT Sensor configuration force_update allow for the sensor to be "updated" with every message received, this resolves this issue.